### PR TITLE
Add Timeouts & Watchdog

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,45 @@
+name: Build and Create Draft Release
+
+on:
+  push:
+    branches:
+      - main
+      - gh_actions
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Prepare environment
+        run: |
+          uv lock
+
+      - name: Build package
+        run: |
+          uv build
+          ls -la dist/
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: "Draft release"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          prerelease: true
+          files: |
+            LICENSE
+            dist/*.whl
+            dist/*.tar.gz
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,5 @@ data/
 serial_config/*.json
 
 .venv/
+
+**/.claude/settings.local.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+      Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2025 John Beeler
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """Serial-to-Fermentrack: Fermentrack REST API client for Serial-connected BrewPi devices."""
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/config_manager.py
+++ b/config_manager.py
@@ -20,7 +20,7 @@ import argparse
 from pathlib import Path
 
 # Version information
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 # Configuration directory
 CONFIG_DIR = Path("serial_config")

--- a/controller/serial_controller.py
+++ b/controller/serial_controller.py
@@ -301,15 +301,19 @@ class SerialController:
     def parse_responses(self, brewpi):
         """Parse all incoming responses from the BrewPi controller.
 
-        Continues reading responses until no more are available.
+        Continues reading responses until no more are available or maximum timeout is reached.
         Handles errors for individual responses without stopping the entire process.
 
         Args:
             brewpi: BrewPiController instance
         """
-        # Continue reading responses until no more are available
+        # Set a maximum timeout for the whole response parsing session (15 seconds)
+        max_timeout = 15  # seconds
+        start_time = time.time()
+
+        # Continue reading responses until no more are available or timeout
         # TODO - Sleep and repeat if we don't end on a newline
-        while True:
+        while time.time() - start_time < max_timeout:
             try:
                 # Read response
                 response = self._read_response()
@@ -335,6 +339,11 @@ class SerialController:
                 logger.error(f"Unexpected error in parse_responses: {e}")
                 # Break the loop on unexpected errors
                 break
+
+        # Check if we hit the timeout
+        if time.time() - start_time >= max_timeout:
+            logger.warning(f"Maximum timeout ({max_timeout}s) reached while parsing responses")
+            # We are exiting due to timeout, not because we're done
 
     def request_lcd(self):
         """Request LCD content.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "serial-to-fermentrack"
-version = "0.0.1"
+version = "0.0.2"
 description = "Fermentrack REST API client for serial-connected BrewPi devices"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/serial_to_fermentrack_daemon.py
+++ b/serial_to_fermentrack_daemon.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 # Version information
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 # Import watchdog for file system monitoring
 try:

--- a/serial_to_fermentrack_daemon.py
+++ b/serial_to_fermentrack_daemon.py
@@ -89,6 +89,9 @@ class DeviceProcess:
         self.restart_delay: int = 5  # seconds to wait before restarting a crashed process
         self.location: str = ""
         self.stopping: bool = False
+        self.last_check_time: float = time.time()  # For limiting log checks
+        self.log_check_interval: int = 60  # Check logs once per minute at most
+        self.max_log_age: int = 12 * 60  # Max log age in minutes (12 minutes)
         self._read_config()
 
     def _read_config(self) -> bool:
@@ -155,18 +158,98 @@ class DeviceProcess:
                 logger.error(f"Error stopping process for {self.location}: {e}")
         self.stopping = False
 
+    def _get_log_file_path(self) -> Optional[Path]:
+        """Get the log file path for this device process.
+
+        Returns:
+            Path to the log file or None if location is not set
+        """
+        if not self.location:
+            return None
+
+        # Uses the same log file pattern as in utils/config.py
+        log_dir = Path('logs')
+        return log_dir / f"{self.location}.log"
+
+    def _check_log_activity(self) -> bool:
+        """Check if the log file has been updated recently.
+
+        Returns:
+            True if log is active, False if it's stale or doesn't exist
+        """
+        log_file = self._get_log_file_path()
+        if not log_file or not log_file.exists():
+            logger.warning(f"Log file for {self.location} not found at {log_file}")
+            return False
+
+        try:
+            # Get the last modification time of the log file
+            log_mtime = os.path.getmtime(log_file)
+            current_time = time.time()
+
+            # Check if log file is too old (hasn't been written to in max_log_age minutes)
+            log_age_minutes = (current_time - log_mtime) / 60
+
+            if log_age_minutes > self.max_log_age:
+                logger.warning(f"Log file for {self.location} is stale ({log_age_minutes:.1f} minutes old, max allowed: {self.max_log_age} minutes)")
+                return False
+
+            return True
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            logger.error(f"Error checking log file for {self.location}: {e}")
+            return False
+
+    def _force_kill_process(self) -> None:
+        """Force kill the process using SIGKILL."""
+        if not self.process or self.process.poll() is not None:
+            return
+
+        logger.warning(f"Force killing stale process for {self.location}")
+        try:
+            # Kill the entire process group with SIGKILL
+            os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+
+            # Wait briefly for the process to exit
+            for _ in range(3):
+                if self.process.poll() is not None:
+                    break
+                time.sleep(1.5)
+
+            if self.process.poll() is None:
+                logger.error(f"Failed to kill process for {self.location}, PID: {self.process.pid}")
+        except ProcessLookupError:
+            # Process already terminated
+            pass
+        except Exception as e:
+            logger.error(f"Error killing process for {self.location}: {e}")
+
     def check_and_restart(self) -> None:
         """Check if the process is running and restart it if necessary."""
         if self.stopping:
             return
-            
+
+        current_time = time.time()
+
         # Check if process has died
         if self.process and self.process.poll() is not None:
             exit_code = self.process.poll()
             logger.warning(f"Process for {self.location} exited with code {exit_code}, restarting in {self.restart_delay} seconds")
             time.sleep(self.restart_delay)
             self.start()
-            
+            return
+
+        # Limit how often we check the log file to reduce system load
+        if self.process and self.process.poll() is None and current_time - self.last_check_time >= self.log_check_interval:
+            self.last_check_time = current_time
+
+            # Check if log file has been updated recently
+            if not self._check_log_activity():
+                logger.warning(f"Process for {self.location} appears to be stale (no log activity for {self.max_log_age} minutes)")
+                self._force_kill_process()
+                logger.info(f"Restarting process for {self.location} after forced kill")
+                self.start()
+                return
+
         # Check if config file has changed
         try:
             current_mtime = os.path.getmtime(self.config_file)

--- a/serial_to_fermentrack_daemon.py
+++ b/serial_to_fermentrack_daemon.py
@@ -400,8 +400,8 @@ def parse_args():
     parser.add_argument('--config-dir', type=str, default='serial_config',
                         help='Directory containing device configuration files (default: ./serial_config)')
     
-    parser.add_argument('--log-dir', type=str, default='log',
-                        help='Directory for log files (default: ./log)')
+    parser.add_argument('--log-dir', type=str, default='logs',
+                        help='Directory for log files (default: ./logs)')
     
     parser.add_argument('--python', type=str, default=sys.executable,
                         help='Python executable to use for launching processes (default: current Python interpreter)')

--- a/tests/test_daemon_log_monitoring.py
+++ b/tests/test_daemon_log_monitoring.py
@@ -1,0 +1,198 @@
+"""Tests for log activity monitoring in the daemon."""
+
+import os
+import time
+import json
+import logging
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock, mock_open, call
+
+from serial_to_fermentrack_daemon import DeviceProcess
+
+
+class TestLogActivityMonitoring:
+    """Tests for the log activity monitoring functionality in DeviceProcess."""
+
+    @pytest.fixture
+    def valid_config_file(self, tmp_path):
+        """Create a valid device config file."""
+        config_file = tmp_path / "1-1.json"
+        config = {"location": "1-1"}
+        with open(config_file, 'w') as f:
+            json.dump(config, f)
+        return config_file
+
+    def test_get_log_file_path(self, valid_config_file):
+        """Test getting the log file path."""
+        device = DeviceProcess(valid_config_file)
+        log_path = device._get_log_file_path()
+        
+        assert log_path is not None
+        assert log_path.name == "1-1.log"
+        assert str(log_path).endswith("logs/1-1.log")
+
+    def test_get_log_file_path_no_location(self, tmp_path):
+        """Test getting log file path with no location."""
+        config_file = tmp_path / "invalid.json"
+        config = {"some_key": "some_value"}
+        with open(config_file, 'w') as f:
+            json.dump(config, f)
+            
+        device = DeviceProcess(config_file)
+        log_path = device._get_log_file_path()
+        
+        assert log_path is None
+
+    @patch('os.path.exists')
+    @patch('os.path.getmtime')
+    def test_check_log_activity_fresh_log(self, mock_getmtime, mock_exists, valid_config_file):
+        """Test checking a log file that's been recently updated."""
+        device = DeviceProcess(valid_config_file)
+        
+        # Mock log file existence
+        mock_exists.return_value = True
+        
+        # Set up mock to return current time - 5 minutes (log is fresh)
+        current_time = time.time()
+        mock_getmtime.return_value = current_time - (5 * 60)
+        
+        result = device._check_log_activity()
+        
+        assert result is True
+        mock_exists.assert_called_once()
+        mock_getmtime.assert_called_once()
+
+    @patch('os.path.exists')
+    @patch('os.path.getmtime')
+    def test_check_log_activity_stale_log(self, mock_getmtime, mock_exists, valid_config_file):
+        """Test checking a log file that's too old."""
+        device = DeviceProcess(valid_config_file)
+        
+        # Mock log file existence
+        mock_exists.return_value = True
+        
+        # Set up mock to return current time - 20 minutes (log is stale, beyond 12 minute default)
+        current_time = time.time()
+        mock_getmtime.return_value = current_time - (20 * 60)
+        
+        result = device._check_log_activity()
+        
+        assert result is False
+        mock_exists.assert_called_once()
+        mock_getmtime.assert_called_once()
+
+    @patch('os.path.exists')
+    def test_check_log_activity_no_log(self, mock_exists, valid_config_file):
+        """Test checking when log file doesn't exist."""
+        device = DeviceProcess(valid_config_file)
+        
+        # Mock log file not existing
+        mock_exists.return_value = False
+        
+        result = device._check_log_activity()
+        
+        assert result is False
+        mock_exists.assert_called_once()
+
+    @patch('os.killpg')
+    @patch('os.getpgid')
+    def test_force_kill_process(self, mock_getpgid, mock_killpg, valid_config_file):
+        """Test force killing a process."""
+        mock_process = MagicMock()
+        mock_process.poll.side_effect = [None, None, None, 0]  # Process terminates after kill
+        mock_process.pid = 12345
+        
+        mock_getpgid.return_value = 12345
+        
+        device = DeviceProcess(valid_config_file)
+        device.process = mock_process
+        
+        device._force_kill_process()
+        
+        # Should kill the process group
+        mock_getpgid.assert_called_once_with(12345)
+        mock_killpg.assert_called_once_with(12345, 9)  # SIGKILL = 9
+        
+        # Should call poll() to check if process terminated
+        assert mock_process.poll.call_count >= 1
+
+    @patch('os.killpg')
+    @patch('os.getpgid')
+    def test_force_kill_already_terminated(self, mock_getpgid, mock_killpg, valid_config_file):
+        """Test force killing a process that's already terminated."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 0  # Process already terminated
+        mock_process.pid = 12345
+        
+        device = DeviceProcess(valid_config_file)
+        device.process = mock_process
+        
+        device._force_kill_process()
+        
+        # Shouldn't try to kill already terminated process
+        mock_getpgid.assert_not_called()
+        mock_killpg.assert_not_called()
+
+    @patch('os.path.getmtime')
+    @patch.object(DeviceProcess, '_check_log_activity')
+    @patch.object(DeviceProcess, '_force_kill_process')
+    @patch.object(DeviceProcess, 'start')
+    def test_check_and_restart_stale_process(self, mock_start, mock_force_kill,
+                                            mock_check_log, mock_getmtime, valid_config_file):
+        """Test checking and restarting a stale process."""
+        # Process is running
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        
+        # Log check interval passed
+        current_time = time.time()
+        
+        # Log activity check returns False (stale log)
+        mock_check_log.return_value = False
+        
+        device = DeviceProcess(valid_config_file)
+        device.process = mock_process
+        device.last_check_time = current_time - 120  # Last check was 2 minutes ago
+        
+        device.check_and_restart()
+        
+        # Should check log activity
+        assert mock_check_log.called
+        # Should force kill and restart
+        assert mock_force_kill.called
+        assert mock_start.called
+
+    @patch('os.path.getmtime')
+    @patch.object(DeviceProcess, '_check_log_activity')
+    @patch.object(DeviceProcess, '_force_kill_process')
+    @patch.object(DeviceProcess, 'start')
+    def test_check_and_restart_active_log(self, mock_start, mock_force_kill,
+                                         mock_check_log, mock_getmtime, valid_config_file):
+        """Test checking a process with active log shouldn't restart it."""
+        # Process is running
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        
+        # Log check interval passed
+        current_time = time.time()
+        
+        # Log activity check returns True (fresh log)
+        mock_check_log.return_value = True
+        
+        # Config file mtime hasn't changed
+        mock_getmtime.return_value = 1000
+        
+        device = DeviceProcess(valid_config_file)
+        device.process = mock_process
+        device.last_check_time = current_time - 120  # Last check was 2 minutes ago
+        device.config_mtime = 1000
+        
+        device.check_and_restart()
+        
+        # Should check log activity
+        assert mock_check_log.called
+        # Shouldn't force kill or restart
+        assert not mock_force_kill.called
+        assert not mock_start.called

--- a/tests/test_parse_responses_timeout.py
+++ b/tests/test_parse_responses_timeout.py
@@ -1,0 +1,56 @@
+"""Test for the timeout functionality in parse_responses method."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from bpr.controller.serial_controller import SerialController
+
+def test_parse_responses_timeout():
+    """Test that parse_responses times out after the maximum timeout period."""
+    # Create a mock brewpi controller
+    mock_brewpi = MagicMock()
+    
+    # Create patchers
+    serial_patcher = patch('bpr.controller.serial_controller.serial.Serial')
+    time_patcher = patch('bpr.controller.serial_controller.time.time')
+    sleep_patcher = patch('time.sleep')
+    logger_patcher = patch('bpr.controller.serial_controller.logger')
+    
+    try:
+        # Start patchers
+        mock_serial_class = serial_patcher.start()
+        mock_time = time_patcher.start()
+        mock_sleep = sleep_patcher.start()
+        mock_logger = logger_patcher.start()
+        
+        # Configure mocks
+        mock_serial = MagicMock()
+        mock_serial_class.return_value = mock_serial
+        
+        # Set up time to simulate the timeout and provide enough values
+        # The pattern is: initial call at the start, calls during loop execution, and the final timeout check
+        mock_time.side_effect = [0, 10, 20, 30, 40, 50]
+        
+        # Configure mock_serial to always have data available (to force timeout)
+        mock_serial.in_waiting = 10
+        mock_serial.read.return_value = b'continuous data without newline'
+        
+        # Create controller and connect
+        controller = SerialController('/dev/ttyUSB0')
+        controller.connected = True
+        controller.serial_conn = mock_serial
+        
+        # Call parse_responses - this should now timeout after 30 seconds
+        controller.parse_responses(mock_brewpi)
+        
+        # Verify that time.time was called multiple times (at least 3)
+        assert mock_time.call_count >= 3
+        
+        # Verify logger.warning was called for the timeout
+        mock_logger.warning.assert_called_with("Maximum timeout (30s) reached while parsing responses")
+    
+    finally:
+        # Stop all patchers
+        serial_patcher.stop()
+        time_patcher.stop()
+        sleep_patcher.stop()
+        logger_patcher.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "serial-to-fermentrack"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "inquirer" },


### PR DESCRIPTION
I noticed yesterday that one of the test builds I had for Serial-to-Fermentrack had stopped sending updates to Fermentrack while the script was still showing as running on the host. This update adds two checks that are intended to prevent this:

## Serial Read Timeout

There is now a 15 second timeout when waiting for a response from the controller. This will resolve a potential scenario where the line break (\n) sent by the controller is missed, causing the script to hang while waiting for the controller to finish sending data.


## Daemon Watchdog

The daemon will now monitor the log files for each launched worker, and - if the log file is not updated within 12 minutes - kill the worker. As currently designed, a full config is sent to Fermentrack every 10 minutes,  with a corresponding log entry written at the same time. Although this check does not directly verify that the worker is still running, it should detect most situations where the script has deadlocked - including ones that are not resolved by the serial read timeout above. 