### PR TITLE
Heartbeat

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """Serial-to-Fermentrack: Fermentrack REST API client for Serial-connected BrewPi devices."""
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/brewpi_rest.py
+++ b/brewpi_rest.py
@@ -9,8 +9,10 @@ import logging
 import time
 import signal
 import sys
+import os
 import argparse
 import uuid
+import threading
 from typing import Dict, Any, Optional, Tuple
 from utils.config import Config, ensure_directories, FERMENTRACK_NET_HOST, FERMENTRACK_NET_PORT, FERMENTRACK_NET_HTTPS
 from utils import setup_logging
@@ -27,6 +29,7 @@ logger = None  # Will be initialized in main() after config is loaded
 STATUS_UPDATE_INTERVAL = 30  # seconds, includes updating status & LCD
 FULL_CONFIG_UPDATE_INTERVAL = 300  # seconds
 FULL_CONFIG_RETRY = 30 # seconds, time to wait after a full config update failed to reattempt
+WATCHDOG_TIMEOUT = 60  # seconds, time to wait before considering the script unresponsive
 
 class BrewPiRest:
     """BrewPi REST application.
@@ -47,6 +50,11 @@ class BrewPiRest:
         self.last_status_update = time.time() - (STATUS_UPDATE_INTERVAL - 5)  # Trigger the initial update after 5 secs
         self.last_message_check = 0
         self.last_full_config_update = 0  # Trigger the initial config update immediately
+
+        # Watchdog attributes
+        self.last_heartbeat = time.time()
+        self.heartbeat_lock = threading.Lock()
+        self.watchdog_thread = None
 
     def setup(self) -> bool:
         """Set up controller and API client.
@@ -290,6 +298,7 @@ class BrewPiRest:
         1. Updates controller status to Fermentrack
         2. Checks for messages from Fermentrack
         3. Periodically updates full configuration
+        4. Maintains heartbeat for watchdog monitoring
         """
         self.running = True
 
@@ -297,10 +306,16 @@ class BrewPiRest:
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
 
+        # Start the watchdog thread
+        self.start_watchdog()
+
         logger.info("Starting Serial-to-Fermentrack main loop")
 
         while self.running:
             try:
+                # Update heartbeat at the start of each loop iteration
+                self.update_heartbeat()
+
                 # Check if it's time to update status
                 current_time = time.time()
 
@@ -483,6 +498,44 @@ class BrewPiRest:
             logger.error(f"Re-registration failed with error: {e}")
             return False
 
+    def update_heartbeat(self) -> None:
+        """Update the heartbeat timestamp to indicate the application is still alive."""
+        with self.heartbeat_lock:
+            self.last_heartbeat = time.time()
+
+    def _watchdog_thread(self) -> None:
+        """Watchdog thread function that monitors application heartbeat.
+
+        If the application doesn't update its heartbeat for WATCHDOG_TIMEOUT seconds,
+        logs a critical error and exits the application.
+        """
+        logger.info("Watchdog thread started")
+
+        while self.running:
+            time.sleep(5)  # Check every 5 seconds
+
+            with self.heartbeat_lock:
+                time_since_heartbeat = time.time() - self.last_heartbeat
+
+            if time_since_heartbeat > WATCHDOG_TIMEOUT:
+                logger.critical(f"WATCHDOG ALERT: Application appears unresponsive for {time_since_heartbeat:.1f} seconds")
+                logger.critical("Initiating emergency shutdown")
+
+                # Force exit with error code
+                # This will be detected by the daemon which can restart the script
+                os._exit(1)
+
+    def start_watchdog(self) -> None:
+        """Start the watchdog thread to monitor application health."""
+        if self.watchdog_thread is None or not self.watchdog_thread.is_alive():
+            self.watchdog_thread = threading.Thread(
+                target=self._watchdog_thread,
+                daemon=True,
+                name="WatchdogThread"
+            )
+            self.watchdog_thread.start()
+            logger.info("Watchdog monitoring started")
+
     def stop(self) -> None:
         """Stop the application."""
         logger.info("Stopping Serial-to-Fermentrack")
@@ -491,6 +544,8 @@ class BrewPiRest:
         # Clean up resources
         if self.controller:
             self.controller.disconnect()
+
+        # The watchdog thread is a daemon thread and will exit automatically
 
 
 def parse_args():

--- a/brewpi_rest.py
+++ b/brewpi_rest.py
@@ -589,7 +589,7 @@ def main() -> int:
     )
 
     # Log startup information
-    logger.info(f"Starting Serial-to-Fermentrack with location: {args.location}")
+    logger.info(f"Starting Serial-to-Fermentrack v{__version__} with location: {args.location}")
     logger.info(f"Using serial port: {config.SERIAL_PORT}")
 
     # Log Fermentrack connection details

--- a/config_manager.py
+++ b/config_manager.py
@@ -20,7 +20,7 @@ import argparse
 from pathlib import Path
 
 # Version information
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 # Configuration directory
 CONFIG_DIR = Path("serial_config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "serial-to-fermentrack"
-version = "0.0.2"
+version = "0.0.3"
 description = "Fermentrack REST API client for serial-connected BrewPi devices"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/serial_to_fermentrack_daemon.py
+++ b/serial_to_fermentrack_daemon.py
@@ -333,12 +333,18 @@ class ConfigWatcher(FileSystemEventHandler):
     def on_created(self, event) -> None:
         """Handle file creation events."""
         if not event.is_directory and event.src_path.endswith('.json'):
+            # Skip the main app config
+            if Path(event.src_path).name == "app_config.json":
+                return
             logger.info(f"New config file detected: {event.src_path}")
             self._handle_config_file(Path(event.src_path))
     
     def on_modified(self, event) -> None:
         """Handle file modification events."""
         if not event.is_directory and event.src_path.endswith('.json'):
+            # Skip the main app config
+            if Path(event.src_path).name == "app_config.json":
+                return
             if event.src_path in self.devices:
                 logger.info(f"Config file modified: {event.src_path}")
                 self.devices[event.src_path].check_and_restart()
@@ -346,6 +352,9 @@ class ConfigWatcher(FileSystemEventHandler):
     def on_deleted(self, event) -> None:
         """Handle file deletion events."""
         if not event.is_directory and event.src_path.endswith('.json'):
+            # Skip the main app config
+            if Path(event.src_path).name == "app_config.json":
+                return
             if event.src_path in self.devices:
                 logger.info(f"Config file deleted: {event.src_path}")
                 self.devices[event.src_path].stop()

--- a/serial_to_fermentrack_daemon.py
+++ b/serial_to_fermentrack_daemon.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 # Version information
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 # Import watchdog for file system monitoring
 try:
@@ -479,11 +479,12 @@ def main():
         logger.debug("Verbose logging enabled")
     
     # Start the daemon
+    logger.info(f"Starting Serial-to-Fermentrack Daemon v{__version__}")
     daemon = SerialToFermentrackDaemon(
         config_dir=config_dir,
         python_exec=args.python
     )
-    
+
     try:
         daemon.run()
     except KeyboardInterrupt:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,238 @@
+"""Tests for Serial-to-Fermentrack watchdog implementation."""
+
+import pytest
+import time
+import os
+import threading
+import sys
+from unittest.mock import MagicMock, patch, ANY
+
+# Add the parent directory to sys.path so that imports work correctly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.config import Config
+from brewpi_rest import BrewPiRest, WATCHDOG_TIMEOUT
+
+@pytest.fixture
+def mock_config():
+    """Create a mock configuration object."""
+    mock_config = MagicMock(spec=Config)
+
+    # Configure mock properties
+    mock_config.DEFAULT_API_URL = "http://localhost:8000"
+    mock_config.API_TIMEOUT = 10
+    mock_config.DEVICE_ID = "test123"
+    mock_config.FERMENTRACK_API_KEY = "abc456"
+    mock_config.SERIAL_PORT = "/dev/ttyUSB0"  # Mock the result of port detection
+    mock_config.LOG_DIR = "/tmp/brewpi-rest/logs"
+    mock_config.LOG_LEVEL = "INFO"
+    mock_config.LOG_FILE = "/tmp/brewpi-rest/logs/brewpi_rest.log"
+    mock_config.LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+    # Mock methods
+    mock_config.get_api_url = lambda endpoint: f"{mock_config.DEFAULT_API_URL}{endpoint}"
+    mock_config.device_config = {"location": "1-1", "fermentrack_id": "test123"}
+    mock_config.save_device_config = MagicMock()
+    mock_config.save_app_config = MagicMock()
+
+    return mock_config
+
+@pytest.fixture
+def app(mock_config):
+    """Create a BrewPiRest app instance with mocks."""
+    with patch("brewpi_rest.BrewPiController"), \
+         patch("brewpi_rest.FermentrackClient"), \
+         patch("brewpi_rest.logger"):
+        # Mock the logger directly in the module
+        import brewpi_rest
+        brewpi_rest.logger = MagicMock()
+
+        # Create app
+        app = BrewPiRest(mock_config)
+        
+        yield app
+
+def test_watchdog_initialization(app):
+    """Test watchdog initialization."""
+    # Check initial attribute values
+    assert hasattr(app, 'last_heartbeat')
+    assert hasattr(app, 'heartbeat_lock')
+    assert hasattr(app, 'watchdog_thread')
+    # In the mocked environment, the lock might be a MagicMock not a threading.Lock
+    assert app.heartbeat_lock is not None
+    assert app.watchdog_thread is None
+    
+    # Initial heartbeat should be recent
+    assert time.time() - app.last_heartbeat < 1.0
+
+def test_start_watchdog(app):
+    """Test starting the watchdog thread."""
+    # Mock the threading.Thread to avoid actual thread creation
+    with patch('threading.Thread') as mock_thread_class:
+        mock_thread = MagicMock()
+        mock_thread.daemon = False
+        mock_thread.is_alive.return_value = True
+        mock_thread.name = "WatchdogThread"
+        mock_thread_class.return_value = mock_thread
+
+        # Start the watchdog
+        app.start_watchdog()
+
+        # Thread should be created
+        assert app.watchdog_thread is not None
+
+        # Verify thread creation with correct parameters
+        mock_thread_class.assert_called_once()
+        kwargs = mock_thread_class.call_args[1]
+        assert kwargs['daemon'] is True
+        assert kwargs['name'] == "WatchdogThread"
+        assert kwargs['target'] == app._watchdog_thread
+
+        # Verify thread was started
+        mock_thread.start.assert_called_once()
+
+def test_update_heartbeat(app):
+    """Test updating the heartbeat."""
+    # Get initial heartbeat time
+    initial_heartbeat = app.last_heartbeat
+    
+    # Wait briefly to ensure time difference
+    time.sleep(0.1)
+    
+    # Update heartbeat
+    app.update_heartbeat()
+    
+    # Heartbeat should be updated
+    assert app.last_heartbeat > initial_heartbeat
+    assert time.time() - app.last_heartbeat < 0.1
+
+def test_watchdog_thread_normal_operation(app):
+    """Test watchdog thread under normal operation."""
+    # Mock time.sleep to avoid actual waiting
+    with patch('time.sleep') as mock_sleep:
+        # Create a mock for os._exit
+        with patch('os._exit') as mock_exit:
+            # Set app.running to True
+            app.running = True
+            
+            # Create a side effect to exit after one iteration
+            def side_effect(*args):
+                app.running = False
+            mock_sleep.side_effect = side_effect
+            
+            # Call _watchdog_thread directly
+            app._watchdog_thread()
+            
+            # Verify that os._exit was not called (no watchdog alert)
+            mock_exit.assert_not_called()
+
+def test_watchdog_thread_detects_unresponsive_app(app):
+    """Test watchdog thread detects an unresponsive application."""
+    # Mock time.sleep to avoid actual waiting
+    with patch('time.sleep') as mock_sleep:
+        # Create a mock for os._exit
+        with patch('os._exit') as mock_exit:
+            # Set app.running to True
+            app.running = True
+            
+            # Set the last heartbeat to be older than the timeout
+            app.last_heartbeat = time.time() - (WATCHDOG_TIMEOUT + 10)
+            
+            # Create a side effect to exit after one iteration
+            def side_effect(*args):
+                app.running = False
+            mock_sleep.side_effect = side_effect
+            
+            # Call _watchdog_thread directly
+            app._watchdog_thread()
+            
+            # Verify that os._exit was called with code 1 (watchdog alert)
+            mock_exit.assert_called_once_with(1)
+
+def test_watchdog_integrated_with_main_loop(app):
+    """Test the watchdog's integration with the main application loop."""
+    # Mock the actual threading.Thread to avoid starting a real thread
+    with patch('threading.Thread') as mock_thread:
+        # Create a mock thread instance
+        mock_thread_instance = MagicMock()
+        mock_thread.return_value = mock_thread_instance
+        
+        # Mock other dependencies to simulate running the app
+        with patch.object(app, 'update_status', return_value=True) as mock_update_status, \
+             patch.object(app, 'update_full_config', return_value=True) as mock_update_config, \
+             patch('time.sleep') as mock_sleep, \
+             patch('signal.signal'):
+            
+            # Make the app stop after one iteration
+            def stop_after_first_iteration(*args):
+                app.running = False
+            mock_sleep.side_effect = stop_after_first_iteration
+            
+            # Run the app
+            app.run()
+            
+            # Verify the watchdog thread was started
+            mock_thread.assert_called_once()
+            mock_thread_instance.start.assert_called_once()
+            
+            # Verify heartbeat was updated during the main loop
+            assert time.time() - app.last_heartbeat < 5.0
+
+def test_watchdog_survives_exceptions_in_main_loop(app):
+    """Test the watchdog continues monitoring despite exceptions in the main loop."""
+    # Mock the actual threading.Thread to avoid starting a real thread
+    with patch('threading.Thread') as mock_thread:
+        # Create a mock thread instance
+        mock_thread_instance = MagicMock()
+        mock_thread.return_value = mock_thread_instance
+        
+        # Mock other dependencies to simulate running the app with an exception
+        with patch.object(app, 'update_status') as mock_update_status, \
+             patch('time.sleep') as mock_sleep, \
+             patch('signal.signal'):
+            
+            # Make update_status raise an exception
+            mock_update_status.side_effect = Exception("Test exception")
+            
+            # Make the app stop after exception handling
+            call_count = 0
+            def stop_after_exception_handling(*args):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:  # Allow one sleep for exception handling
+                    app.running = False
+            mock_sleep.side_effect = stop_after_exception_handling
+            
+            # Initial heartbeat time
+            initial_heartbeat = app.last_heartbeat
+            
+            # Run the app
+            app.run()
+            
+            # Verify the watchdog thread was started
+            mock_thread.assert_called_once()
+            mock_thread_instance.start.assert_called_once()
+            
+            # Heartbeat should still be updated even with the exception
+            assert app.last_heartbeat >= initial_heartbeat
+
+def test_daemon_thread_auto_cleanup(app):
+    """Test daemon thread auto-cleanup on application exit."""
+    # Mock the actual threading.Thread to create a daemon thread
+    with patch('threading.Thread') as mock_thread:
+        # Create a mock thread instance
+        mock_thread_instance = MagicMock()
+        mock_thread_instance.daemon = True
+        mock_thread.return_value = mock_thread_instance
+        
+        # Start the watchdog
+        app.start_watchdog()
+        
+        # Stop the application
+        app.stop()
+        
+        # Verify the thread was marked as daemon
+        assert mock_thread_instance.daemon is True
+        
+        # No explicit thread cleanup should be done
+        # The daemon threads are automatically cleaned up by Python when main thread exits

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "serial-to-fermentrack"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "inquirer" },


### PR DESCRIPTION
This pull request introduces a new watchdog mechanism to monitor the health of the `Serial-to-Fermentrack` application, along with several improvements to versioning, configuration handling, and testing. The most significant changes include implementing the watchdog functionality, updating version numbers across multiple files, enhancing configuration file handling, and adding comprehensive tests for the new features.

### Watchdog Implementation:
* Introduced a `WATCHDOG_TIMEOUT` constant and added a watchdog mechanism in `brewpi_rest.py` to monitor application responsiveness. The watchdog thread logs a critical error and exits the application if it becomes unresponsive (currently for 60 seconds) 

### Version Updates:
* Updated the version number from `0.0.2` to `0.0.3`
* Added logging of the version number to individual controller and daemon logs

### Configuration Handling Enhancements:
* Modified the `serial_to_fermentrack_daemon.py` event handlers (`on_created`, `on_modified`, `on_deleted`) to ignore `app_config.json`, ensuring that only device-specific configuration files are processed. 
